### PR TITLE
Simple support of negative index in array

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -644,6 +644,10 @@ value from another array) to get at an array value:
 
 This will make .@arrayofnumbers[100] equal to 10.
 
+	.@arrayofnumbers[-1] = 20;
+
+This will make .@arrayofnumbers[100] (the last index) equal to 20.
+
 Index numbering always starts with 0 and arrays can hold over 2 billion
 variables. As such, the (guaranteed) allowed values for indices are in the
 range 0 ~ 2147483647.

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -6522,12 +6522,16 @@ BUILDIN_FUNC(getelementofarray)
 	id = reference_getid(data);
 
 	i = script_getnum(st, 3);
-	if (i < 0 || i >= SCRIPT_MAX_ARRAYSIZE) {
+	if (std::abs(i) >= SCRIPT_MAX_ARRAYSIZE) {
 		ShowWarning("script:getelementofarray: index out of range (%" PRId64 ")\n", i);
 		script_reportdata(data);
 		script_pushnil(st);
 		st->state = END;
 		return SCRIPT_CMD_FAILURE;// out of range
+	}
+	if (i < 0) {
+		struct map_session_data* sd = NULL;
+		i = cap_value( (script_array_highest_key(st, sd, reference_getname(data), reference_getref(data)) + i), 0, SCRIPT_MAX_ARRAYSIZE );
 	}
 
 	push_val2(st->stack, C_NAME, reference_uid(id, i), reference_getref(data));


### PR DESCRIPTION



<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
-1 : getarraysize() - 1
-2 : getarraysize() - 2
Downside: no more warning when the index is negative (which was often used to check).

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
